### PR TITLE
use the correct user types for Lucia `DatabaseUserAttributes`

### DIFF
--- a/template_builder/templates/extras/src/lib/server/{Auth,D1}auth.ts
+++ b/template_builder/templates/extras/src/lib/server/{Auth,D1}auth.ts
@@ -1,3 +1,4 @@
+import type { Selectable } from 'kysely';
 import { Lucia } from 'lucia';
 import { D1Adapter } from '@lucia-auth/adapter-sqlite';
 import { dev } from '$app/environment';
@@ -35,6 +36,6 @@ export function initLucia(db: D1Database, origin: string) {
 declare module 'lucia' {
 	interface Register {
 		Lucia: typeof lucia;
-		DatabaseUserAttributes: DB['User'];
+		DatabaseUserAttributes: Selectable<DB['User']>;
 	}
 }

--- a/template_builder/templates/extras/src/lib/server/{Auth,Planetscale}auth.ts
+++ b/template_builder/templates/extras/src/lib/server/{Auth,Planetscale}auth.ts
@@ -1,3 +1,4 @@
+import type { Selectable } from 'kysely';
 import { Lucia } from 'lucia';
 import { PlanetScaleAdapter } from '@lucia-auth/adapter-mysql';
 import { dev } from '$app/environment';
@@ -51,6 +52,6 @@ export function initLucia(origin: string) {
 declare module 'lucia' {
 	interface Register {
 		Lucia: typeof lucia;
-		DatabaseUserAttributes: DB['User'];
+		DatabaseUserAttributes: Selectable<DB['User']>;
 	}
 }

--- a/template_builder/templates/extras/src/lib/server/{Auth,Sqlite}auth.ts
+++ b/template_builder/templates/extras/src/lib/server/{Auth,Sqlite}auth.ts
@@ -1,3 +1,4 @@
+import type { Selectable } from 'kysely';
 import { Lucia } from 'lucia';
 import { BetterSqlite3Adapter } from '@lucia-auth/adapter-sqlite';
 import { dev } from '$app/environment';
@@ -34,6 +35,6 @@ export function initLucia(origin: string) {
 declare module 'lucia' {
 	interface Register {
 		Lucia: typeof lucia;
-		DatabaseUserAttributes: DB['User'];
+		DatabaseUserAttributes: Selectable<DB['User']>;
 	}
 }

--- a/template_builder/templates/extras/src/lib/server/{Auth,Turso}auth.ts
+++ b/template_builder/templates/extras/src/lib/server/{Auth,Turso}auth.ts
@@ -1,3 +1,4 @@
+import type { Selectable } from 'kysely';
 import { Lucia } from 'lucia';
 import { LibSQLAdapter } from '@lucia-auth/adapter-sqlite';
 import { dev } from '$app/environment';
@@ -34,6 +35,6 @@ export function initLucia(origin: string) {
 declare module 'lucia' {
 	interface Register {
 		Lucia: typeof lucia;
-		DatabaseUserAttributes: DB['User'];
+		DatabaseUserAttributes: Selectable<DB['User']>;
 	}
 }


### PR DESCRIPTION
The user attributes are not always the correct types due to how the table schema is exported. For example, if I have a user field `updatedAt  DateTime`, the type of `DB['User']['updatedAt']` is `ColumnType<Date, string | Date | undefined, string | Date>` which contains the types for select/insert/update respectively. We only want the `select` types since that is what this is returning

From the [Kysely docs](https://kysely.dev/docs/getting-started#types):

> // You should not use the table schema interfaces directly. Instead, you should
> // use the `Selectable`, `Insertable` and `Updateable` wrappers. These wrappers
> // make sure that the correct types are used in each operation.

By using `Selectable<DB['User']>` we return the correct `Date` type for this field (and all user fields)

I've been tracking https://github.com/valtyr/prisma-kysely/issues/81 (and the related PR), which could ease this problem a bit but there's been no movement on it in a while