### PR TITLE
remove mention of lucia when selecting auth

### DIFF
--- a/template_builder/templates/config.json
+++ b/template_builder/templates/config.json
@@ -5,7 +5,7 @@
 		{
 			"id": "Auth",
 			"name": "Auth",
-			"description": "(with Lucia)",
+			"description": "",
 			"default": false
 		},
 		{

--- a/template_builder/templates/config.json
+++ b/template_builder/templates/config.json
@@ -5,7 +5,7 @@
 		{
 			"id": "Auth",
 			"name": "Auth",
-			"description": "",
+			"description": "(based off lucia)",
 			"default": false
 		},
 		{


### PR DESCRIPTION
This tripped me up the other day, started a new project and just learned of lucia's demise, so i didn't select this option, even though it should be fine to use.

Could also maybe change the description to "(based off lucia)" or something, just thought id highlight this.