### PR TITLE
Disable referential actions during D1 database migration

### DIFF
--- a/template_builder/templates/extras/prisma/{D1}push.mjs
+++ b/template_builder/templates/extras/prisma/{D1}push.mjs
@@ -92,7 +92,13 @@ if (migration.stdout.includes('-- This is an empty migration.')) {
 const migrationSql = migration.stdout
 	.replace(/^PRAGMA foreign_keys=OFF;/gm, 'PRAGMA defer_foreign_keys=true;')
 	.replace(/^PRAGMA foreign_keys=ON;/gm, 'PRAGMA defer_foreign_keys=false;')
-	.replace(/^PRAGMA foreign_key_check;/gm, '');
+	.replace(/^PRAGMA foreign_key_check;/gm, '')
+	.replace(/ON DELETE CASCADE/gm, 'ON DELETE NO ACTION')
+	.replace(/ON UPDATE CASCADE/gm, 'ON UPDATE NO ACTION')
+	.replace(/ON DELETE SET NULL/gm, 'ON DELETE NO ACTION')
+	.replace(/ON UPDATE SET NULL/gm, 'ON UPDATE NO ACTION')
+	.replace(/ON DELETE SET DEFAULT/gm, 'ON DELETE NO ACTION')
+	.replace(/ON UPDATE SET DEFAULT/gm, 'ON UPDATE NO ACTION');
 console.log(migrationSql);
 
 writeFileSync(migrationFile, migrationSql);


### PR DESCRIPTION
When using [referential actions](https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/referential-actions) in the prisma database schema for a cloudflare d1 database, simply running a migration which adds a new column to a table that has been referenced by a field in another table will cause the referential action to be executed. This can cause unintended data loss as shown in the example below.

When adding a new `tag` column to the `User` table, the `created_by` column in the `Message` table will cause the cascade action to delete the message during the migration. This PR aims to disable any referential actions during the migration process and fixes this problem.

```prisma
model User {
    id             String   @id
    username       String   @unique

    // We would like to add the column below
    tag            String?

    created_at     DateTime @default(now())
}

model Message {
    id             String   @id
    message        String
    created_by     String?
    created_at     DateTime @default(now())

    // This reference will cause the message to be deleted during the migration
    User          User?     @relation(fields: [created_by], references: [id], onDelete: Cascade)
}
```
