### PR TITLE
Update invalid svelte learnMore URL

### DIFF
--- a/template_builder/templates/base/src/routes/+page.svelte
+++ b/template_builder/templates/base/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 	<div class="flex max-w-5xl justify-center gap-4 px-3">
 		<NextStep
 			title="Edit this page"
-			learnMore="https://svelte.dev/tutorial/basics"
+			learnMore="https://svelte.dev/tutorial"
 		>
 			<p>
 				Edit <code class="text-lime-300">src/routes/+page.svelte</code> to see your


### PR DESCRIPTION
Current URL for svelte learn more link leads you to not found page. 

We fix it with updating the URL to a more generic one, and which is used on svelte's website navbar for tutorial.