### PR TITLE
fix windows file lock issue

### DIFF
--- a/template_builder/templates/extras/prisma/{D1}push.mjs
+++ b/template_builder/templates/extras/prisma/{D1}push.mjs
@@ -61,6 +61,7 @@ for (const item of current) {
 		db.prepare(item.sql).run();
 	}
 }
+db.close();
 
 // 3. generate migration on dummy db
 const migration = spawnSync(

--- a/template_builder/templates/extras/prisma/{Turso}push.mjs
+++ b/template_builder/templates/extras/prisma/{Turso}push.mjs
@@ -37,6 +37,7 @@ for (const item of current.rows) {
 		db.prepare(item.sql).run();
 	}
 }
+db.close();
 
 // 3. generate migration on dummy db
 const migration = spawnSync(


### PR DESCRIPTION
When running the command `bun db:push` or `bun db:push:local`:
```ps1
PS C:\Users\phrog\Code\_\web> bun db:push:local
$ bun ./prisma/push.mjs --local
No changes
83 |    unlinkSync(tempDb);
84 |    process.exit(0);
85 | }
86 | if (migration.stdout.includes('-- This is an empty migration.')) {
87 |    console.log('No changes');
88 |    unlinkSync(tempDb);
      ^
EBUSY: resource busy or locked, unlink 'C:\Users\phrog\Code\alignofficesystems\web\prisma\temp.db'
    path: "C:\\Users\\phrog\\Code\\alignofficesystems\\web\\prisma\\temp.db",
 syscall: "unlink",
   errno: -16,
    code: "EBUSY"

      at C:\Users\phrog\Code\alignofficesystems\web\prisma\push.mjs:88:2
      at loadAndEvaluateModule (2:1)

Bun v1.2.20 (Windows x64)
error: script "db:push:local" exited with code 1
```
At first, I thought it was corrupted windows OS, but testing with a fresh install also gave me the same issue.

This happens because Windows will lock in-use files, which prevents `unlinkSync` from removing `temp.db`.

This appears to be Windows-specific because I didn't experience this issue on Linux.

<img width="348" height="99" alt="Screenshot 2025-09-13 144108" src="https://github.com/user-attachments/assets/0525b32f-ca91-489d-beef-7838e5c003b0" />
